### PR TITLE
Actual initial code commit

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,0 +1,26 @@
+# Based on https://github.com/dockerfile/rethinkdb
+FROM quay.io/aptible/ubuntu:14.04
+
+ENV DATA_DIRECTORY /var/db
+
+# Install RethinkDB
+RUN apt-install wget
+ADD files/etc /etc
+RUN wget -O- http://download.rethinkdb.com/apt/pubkey.gpg | apt-key add - && \
+    apt-install rethinkdb python-pip
+
+# Install Python driver
+RUN pip install rethinkdb
+
+ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
+
+ADD test /tmp/test
+RUN bats /tmp/test
+
+VOLUME ["$DATA_DIRECTORY"]
+WORKDIR $DATA_DIRECTORY
+
+EXPOSE 28015
+
+ENTRYPOINT ["run-database.sh"]

--- a/2.0/files/etc/apt/sources.list.d/rethinkdb.list
+++ b/2.0/files/etc/apt/sources.list.d/rethinkdb.list
@@ -1,0 +1,1 @@
+deb http://download.rethinkdb.com/apt trusty main

--- a/2.0/run-database.sh
+++ b/2.0/run-database.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+. /usr/bin/utilities.sh
+
+start_server() {
+  rethinkdb --bind all --directory "$DATA_DIRECTORY" $@
+}
+
+if [[ "$1" == "--initialize" ]]; then
+  start_server --daemon
+  python - << PYTHON
+import time, rethinkdb
+# Server may take several seconds to start...
+while True:
+  try:
+    conn = rethinkdb.connect(host='localhost', port=28015)
+  except rethinkdb.errors.RqlDriverError:
+    print 'Waiting for server...'
+    time.sleep(1)
+    continue
+  break
+auth = rethinkdb.db('rethinkdb').table('cluster_config').get('auth')
+auth.update({'auth_key': 'foobar'}).run(conn)
+PYTHON
+
+elif [[ "$1" == "--client" ]]; then
+  echo "This image does not support the --client option. Use curl instead."
+  exit 1
+
+elif [[ "$1" == "--readonly" ]]; then
+  # https://github.com/rethinkdb/rethinkdb/issues/1805
+  echo "This image does not support read-only mode. Starting database normally."
+  start_server
+
+else
+  start_server
+
+fi

--- a/2.0/test/rethinkdb.bats
+++ b/2.0/test/rethinkdb.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+@test "It should install RethinkDB 2.0.4" {
+  run rethinkdb --version
+  [[ "$output" =~ "rethinkdb 2.0.4" ]]
+}
+
+@test "It should install the RethinkDB Python library" {
+  echo "import rethinkdb" | python -
+}

--- a/2.0/utilities.sh
+++ b/2.0/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+Copyright (c) 2015 Aptible, Inc.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+DOCKER = docker
+REPO = git@github.com:aptible/docker-rethinkdb.git
+TAGS = 2.0
+
+all: release
+
+sync-branches:
+	git fetch $(REPO) master
+	@$(foreach tag, $(TAGS), git branch -f $(tag) FETCH_HEAD;)
+	@$(foreach tag, $(TAGS), git push $(REPO) $(tag);)
+	@$(foreach tag, $(TAGS), git branch -D $(tag);)
+
+release: $(TAGS)
+	$(DOCKER) push quay.io/aptible/rethinkdb
+
+build: $(TAGS)
+
+.PHONY: $(TAGS)
+$(TAGS):
+	$(DOCKER) build -t quay.io/aptible/rethinkdb:$@ $@

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# docker-rethinkdb
+# ![](https://gravatar.com/avatar/11d3bc4c3163e3d238d558d5c9d98efe?s=64) aptible/rethinkdb
+[![Docker Repository on Quay.io](https://quay.io/repository/aptible/rethinkdb/status)](https://quay.io/repository/aptible/rethinkdb)
+
+[![](http://dockeri.co/image/aptible/rethinkdb)](https://registry.hub.docker.com/u/aptible/rethinkdb/)
+
 RethinkDB on Docker
+
+## Installation and Usage
+
+    docker pull quay.io/aptible/rethinkdb
+
+This is an image conforming to the [Aptible database specification](https://support.aptible.com/topics/paas/deploy-custom-database/). To run a server for development purposes, execute
+
+    docker create --name data quay.io/aptible/rethinkdb
+    docker run --volumes-from data -e PASSPHRASE=pass quay.io/aptible/rethinkdb --initialize
+    docker run --volumes-from data -P quay.io/aptible/rethinkdb
+
+The first command sets up a data container named `data` which will hold the configuration and data for the database. The second command creates a RethinkDB instance with the passphrase of your choice. The third command starts the database server.
+
+## Available Tags
+
+* `latest`: Currently RethinkDB 2.0.4
+* `2.0`: RethinkDB 2.0.4
+
+## Tests
+
+Tests are run as part of the `Dockerfile` build. To execute them separately within a container, run:
+
+    bats test
+
+## Continuous Integration
+
+Images are built and pushed to Docker Hub on every deploy. Because Quay currently only supports build triggers where the Docker tag name exactly matches a GitHub branch/tag name, we must run the following script to synchronize all our remote branches after a merge to master:
+
+    make sync-branches
+
+## Deployment
+
+To push the Docker image to Quay, run the following command:
+
+    make release
+
+## Copyright and License
+
+MIT License, see [LICENSE](LICENSE.md) for details.
+
+Copyright (c) 2015 [Aptible](https://www.aptible.com) and contributors.
+
+[<img src="https://s.gravatar.com/avatar/f7790b867ae619ae0496460aa28c5861?s=60" style="border-radius: 50%;" alt="@fancyremarker" />](https://github.com/fancyremarker)


### PR DESCRIPTION
This leaves out `--dump` and `--restore` flags, which are definitely supported by RethinkDB, but which I'm deferring to #1.

It also leaves out `--client`, since there's no real standalone REPL client for RethinkDB. See #2 for discussion thereupon.